### PR TITLE
Add registration flow and default user

### DIFF
--- a/components/auth/login-component.js
+++ b/components/auth/login-component.js
@@ -1,13 +1,29 @@
-import { Button, Col, Form, Input, Row, message } from "antd"
+import { Button, Col, Form, Input, Row, Typography, message } from "antd"
 import Image from "next/image"
+import Link from "next/link"
 import { useRouter } from "next/router"
+import { ensureDefaultUser, getStoredUsers, defaultUser } from "@/lib/auth-storage"
+import { useEffect } from "react"
+
+const { Text } = Typography
 
 const LoginComponent = () => {
   const router = useRouter()
 
+  useEffect(() => {
+    ensureDefaultUser()
+  }, [])
+
   const onFinish = values => {
     const { username, password } = values
-    if (username === "admin" && password === "password123") {
+    const users = getStoredUsers()
+
+    const isAdmin = username === "admin" && password === "password123"
+    const isStoredUser = users.some(
+      user => user.username === username && user.password === password
+    )
+
+    if (isAdmin || isStoredUser) {
       message.success("¡Inicio de sesión exitoso!")
       router.push("/dashboard")
     } else {
@@ -46,6 +62,16 @@ const LoginComponent = () => {
             </Button>
           </Form.Item>
         </Form>
+        <div className="auth-extra">
+          <Text type="secondary">
+            También puedes entrar con usuario &quot;{defaultUser.username}&quot; y contraseña
+            &quot;{defaultUser.password}&quot;.
+          </Text>
+          <div className="auth-links">
+            <Text>¿No tienes cuenta?</Text>
+            <Link href="/registro">Crear usuario</Link>
+          </div>
+        </div>
       </Col>
     </Row>
   )

--- a/components/auth/register-component.js
+++ b/components/auth/register-component.js
@@ -1,0 +1,76 @@
+import { Button, Col, Form, Input, Row, Typography, message } from "antd"
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/router"
+import { getStoredUsers, saveStoredUsers } from "@/lib/auth-storage"
+
+const { Text } = Typography
+
+const RegisterComponent = () => {
+  const router = useRouter()
+
+  const onFinish = values => {
+    const { username, password, confirmPassword } = values
+    const users = getStoredUsers()
+
+    if (users.some(user => user.username === username)) {
+      message.error("El usuario ya existe, prueba con otro nombre")
+      return
+    }
+
+    if (password !== confirmPassword) {
+      message.error("Las contraseñas no coinciden")
+      return
+    }
+
+    saveStoredUsers([...users, { username, password }])
+    message.success("Usuario creado, ahora puedes iniciar sesión")
+    router.push("/login")
+  }
+
+  return (
+    <Row
+      justify="center" align="middle"
+      className="login-container">
+      <Col
+        xs={24} sm={18}
+        md={12} lg={8}>
+        <Row justify="center">
+          <Image
+            width={450} height={450}
+            src="/1.png" alt="logo" />
+        </Row>
+        <Form layout="vertical" onFinish={onFinish}>
+          <Form.Item
+            name="username"
+            rules={[{ required: true, message: "¡Por favor ingresa un nombre de usuario!" }]}>
+            <Input placeholder="Nombre de usuario" />
+          </Form.Item>
+          <Form.Item
+            name="password"
+            rules={[{ required: true, message: "¡Por favor ingresa una contraseña!" }]}>
+            <Input.Password placeholder="Contraseña" />
+          </Form.Item>
+          <Form.Item
+            name="confirmPassword"
+            rules={[{ required: true, message: "Repite la contraseña" }]}>
+            <Input.Password placeholder="Confirmar contraseña" />
+          </Form.Item>
+          <Form.Item>
+            <Button
+              type="primary" htmlType="submit"
+              block>
+              Crear usuario
+            </Button>
+          </Form.Item>
+        </Form>
+        <div className="auth-links">
+          <Text>¿Ya tienes cuenta?</Text>
+          <Link href="/login">Volver a iniciar sesión</Link>
+        </div>
+      </Col>
+    </Row>
+  )
+}
+
+export default RegisterComponent

--- a/components/cargar/canva-preview.js
+++ b/components/cargar/canva-preview.js
@@ -1,0 +1,40 @@
+import { Button, Card, Typography } from "antd"
+
+const CanvaPreview = ({ preview, embedLink, canvaLink }) => (
+  <>
+    <Card title="Vista previa" className="preview-card">
+      <Typography.Title level={4} className="preview-title">{preview.title}</Typography.Title>
+      <Typography.Text className="preview-tone">Tono principal: {preview.tone}</Typography.Text>
+      <div className="lyrics-preview">
+        <Typography.Paragraph>
+          {preview.lyrics ? preview.lyrics : "Aquí verás tu letra con acordes"}
+        </Typography.Paragraph>
+      </div>
+    </Card>
+    <Card title="Diseño de Canva" className="canva-card">
+      {embedLink ? (
+        <iframe
+          className="canva-embed"
+          src={embedLink}
+          allowFullScreen
+          loading="lazy"
+          title="Vista previa de Canva" />
+      ) : (
+        <div className="empty-embed">
+          <Typography.Text className="hint-text">Pega el enlace de Canva para ver la incrustación.</Typography.Text>
+        </div>
+      )}
+      <div className="canva-actions">
+        <Button
+          type="link"
+          href={canvaLink || "https://www.canva.com/"}
+          target="_blank"
+          rel="noreferrer">
+          Abrir Canva
+        </Button>
+      </div>
+    </Card>
+  </>
+)
+
+export default CanvaPreview

--- a/components/cargar/canva-preview.js
+++ b/components/cargar/canva-preview.js
@@ -1,4 +1,4 @@
-import { Button, Card, Typography } from "antd"
+import { Button, Card, Tag, Typography } from "antd"
 
 const CanvaPreview = ({ preview, embedLink, canvaLink }) => (
   <>
@@ -6,9 +6,21 @@ const CanvaPreview = ({ preview, embedLink, canvaLink }) => (
       <Typography.Title level={4} className="preview-title">{preview.title}</Typography.Title>
       <Typography.Text className="preview-tone">Tono principal: {preview.tone}</Typography.Text>
       <div className="lyrics-preview">
-        <Typography.Paragraph>
-          {preview.lyrics ? preview.lyrics : "Aquí verás tu letra con acordes"}
-        </Typography.Paragraph>
+        {preview.sections?.length ? preview.sections.map(section => (
+          <div className="section-preview" key={section.id}>
+            <div className="section-header">
+              <Tag color="geekblue">{section.tone || preview.tone}</Tag>
+              <Typography.Text className="section-label">{section.label}</Typography.Text>
+            </div>
+            <Typography.Paragraph className="section-text">
+              {section.text || "Agrega la letra de este bloque para ver la vista previa"}
+            </Typography.Paragraph>
+          </div>
+        )) : (
+          <Typography.Paragraph>
+            Aquí verás tu letra con acordes y cada bloque con su tono.
+          </Typography.Paragraph>
+        )}
       </div>
     </Card>
     <Card title="Diseño de Canva" className="canva-card">

--- a/components/cargar/sections-editor.js
+++ b/components/cargar/sections-editor.js
@@ -1,0 +1,64 @@
+import { Button, Card, Col, Input, Row, Select, Space, Tag } from "antd"
+import { ArrowDownOutlined, ArrowUpOutlined } from "@ant-design/icons"
+import { tonalidades } from "@/lib/canva"
+
+const SectionsEditor = ({ sections, onChangeSection, onMove }) => (
+  <Card title="Secciones de la letra" className="sections-card">
+    <Space
+      direction="vertical"
+      size={16}
+      style={{ width: "100%" }}>
+      {sections.map((section, index) => (
+        <Card
+          key={section.id}
+          size="small"
+          className="section-item"
+          title={<SectionTitle index={index} label={section.label} />}>
+          <Row gutter={[12, 12]} align="middle">
+            <Col xs={24} sm={10}>
+              <Select
+                value={section.tone}
+                onChange={value => onChangeSection(section.id, "tone", value)}
+                placeholder="Tono de la sección"
+                options={tonalidades.map(t => ({ label: t, value: t }))}
+                className="tone-select" />
+            </Col>
+            <Col
+              xs={24}
+              sm={14}
+              className="move-controls">
+              <Button
+                icon={<ArrowUpOutlined />}
+                disabled={index === 0}
+                onClick={() => onMove(index, -1)}>
+                Subir
+              </Button>
+              <Button
+                icon={<ArrowDownOutlined />}
+                disabled={index === sections.length - 1}
+                onClick={() => onMove(index, 1)}>
+                Bajar
+              </Button>
+            </Col>
+            <Col span={24}>
+              <Input.TextArea
+                value={section.text}
+                rows={3}
+                placeholder="Agrega la letra y marca dónde va el tono (ej: [C]Grande es el Señor)"
+                onChange={event => onChangeSection(section.id, "text", event.target.value)} />
+            </Col>
+          </Row>
+        </Card>
+      ))}
+    </Space>
+  </Card>
+)
+
+const SectionTitle = ({ index, label }) => (
+  <Space>
+    <Tag color="blue">{`Bloque ${index + 1}`}</Tag>
+    <span>{label}</span>
+  </Space>
+)
+
+export default SectionsEditor

--- a/components/cargar/song-form.js
+++ b/components/cargar/song-form.js
@@ -1,0 +1,55 @@
+import { Button, Card, Col, Form, Input, Row, Select } from "antd"
+import { tonalidades } from "@/lib/canva"
+
+const SongForm = ({ form, onFinish, onValuesChange, onReset, onCanvaChange }) => (
+  <Card title="Información de la canción" className="upload-card">
+    <Form
+      layout="vertical"
+      form={form}
+      onFinish={onFinish}
+      onValuesChange={onValuesChange}>
+      <Form.Item
+        name="title"
+        label="Título"
+        rules={[{ required: true, message: "Ingresa el título de la canción" }]}>
+        <Input placeholder="Ej: Eres Fiel" />
+      </Form.Item>
+      <Form.Item
+        name="tone"
+        label="Tono"
+        rules={[{ required: true, message: "Selecciona el tono" }]}>
+        <Select
+          showSearch
+          placeholder="Elige el tono"
+          options={tonalidades.map(tone => ({ value: tone, label: tone }))} />
+      </Form.Item>
+      <Form.Item
+        name="lyrics"
+        label="Letra con acordes"
+        rules={[{ required: true, message: "Agrega la letra con sus acordes" }]}>
+        <Input.TextArea
+          rows={6}
+          placeholder="Escribe la letra y marca los acordes, por ejemplo: [C]Grande es el Señor" />
+      </Form.Item>
+      <Form.Item
+        name="canva"
+        label="Enlace de Canva"
+        extra="Pega el enlace para compartir del diseño y generaremos un embed."
+        rules={[{ required: true, message: "Agrega el enlace de Canva" }]}>
+        <Input
+          placeholder="https://www.canva.com/design/"
+          onChange={event => onCanvaChange(event.target.value)} />
+      </Form.Item>
+      <Row gutter={12} justify="end">
+        <Col>
+          <Button onClick={onReset}>Limpiar</Button>
+        </Col>
+        <Col>
+          <Button type="primary" htmlType="submit">Guardar para Canva</Button>
+        </Col>
+      </Row>
+    </Form>
+  </Card>
+)
+
+export default SongForm

--- a/components/cargar/song-form.js
+++ b/components/cargar/song-form.js
@@ -24,14 +24,6 @@ const SongForm = ({ form, onFinish, onValuesChange, onReset, onCanvaChange }) =>
           options={tonalidades.map(tone => ({ value: tone, label: tone }))} />
       </Form.Item>
       <Form.Item
-        name="lyrics"
-        label="Letra con acordes"
-        rules={[{ required: true, message: "Agrega la letra con sus acordes" }]}>
-        <Input.TextArea
-          rows={6}
-          placeholder="Escribe la letra y marca los acordes, por ejemplo: [C]Grande es el Señor" />
-      </Form.Item>
-      <Form.Item
         name="canva"
         label="Enlace de Canva"
         extra="Pega el enlace para compartir del diseño y generaremos un embed."

--- a/components/dashboard.js
+++ b/components/dashboard.js
@@ -1,9 +1,16 @@
-import { Card , Col , Row , Typography } from "antd"
+import { Card, Col, Row, Typography } from "antd"
 import { UploadOutlined, AppstoreAddOutlined, UnorderedListOutlined } from "@ant-design/icons"
+import { useRouter } from "next/router"
 
 const { Meta } = Card
 
 const Dashboard = () => {
+  const router = useRouter()
+
+  const navigateTo = path => {
+    router.push(path)
+  }
+
   return (
     <Row
       className="dashboard" justify="center"

--- a/components/layout/menu-items.js
+++ b/components/layout/menu-items.js
@@ -1,4 +1,4 @@
-import { HomeOutlined  } from "@ant-design/icons"
+import { HomeOutlined, UploadOutlined } from "@ant-design/icons"
 import Link from "next/link"
 
 export const menuItems = [
@@ -6,5 +6,10 @@ export const menuItems = [
     key: "/",
     icon: <HomeOutlined />,
     label: <Link href="/">Inicio</Link>
+  },
+  {
+    key: "/cargar",
+    icon: <UploadOutlined />,
+    label: <Link href="/cargar">Cargar letras</Link>
   }
 ]

--- a/components/layout/menu-items.js
+++ b/components/layout/menu-items.js
@@ -1,4 +1,4 @@
-import { HomeOutlined, UploadOutlined } from "@ant-design/icons"
+import { AppstoreAddOutlined, HomeOutlined, UnorderedListOutlined, UploadOutlined } from "@ant-design/icons"
 import Link from "next/link"
 
 export const menuItems = [
@@ -11,5 +11,15 @@ export const menuItems = [
     key: "/cargar",
     icon: <UploadOutlined />,
     label: <Link href="/cargar">Cargar letras</Link>
+  },
+  {
+    key: "/servicios",
+    icon: <AppstoreAddOutlined />,
+    label: <Link href="/servicios">Servicios</Link>
+  },
+  {
+    key: "/chord-list",
+    icon: <UnorderedListOutlined />,
+    label: <Link href="/chord-list">Chord List</Link>
   }
 ]

--- a/lib/auth-storage.js
+++ b/lib/auth-storage.js
@@ -1,0 +1,38 @@
+const USERS_KEY = "appUsers"
+
+const isBrowser = () => typeof window !== "undefined"
+
+export const defaultUser = { username: "usuario", password: "canva123" }
+
+export const getStoredUsers = () => {
+  if (!isBrowser()) return []
+
+  const rawUsers = window.localStorage.getItem(USERS_KEY)
+
+  if (!rawUsers) return []
+
+  try {
+    const parsed = JSON.parse(rawUsers)
+    return Array.isArray(parsed) ? parsed : []
+  } catch (error) {
+    console.error("Error al leer los usuarios almacenados", error)
+    return []
+  }
+}
+
+export const saveStoredUsers = users => {
+  if (!isBrowser()) return
+
+  window.localStorage.setItem(USERS_KEY, JSON.stringify(users))
+}
+
+export const ensureDefaultUser = () => {
+  if (!isBrowser()) return
+
+  const users = getStoredUsers()
+  const hasDefaultUser = users.some(user => user.username === defaultUser.username)
+
+  if (!hasDefaultUser) {
+    saveStoredUsers([...users, defaultUser])
+  }
+}

--- a/lib/canva.js
+++ b/lib/canva.js
@@ -1,0 +1,22 @@
+export const tonalidades = [
+  "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+  "Cm", "C#m", "Dm", "D#m", "Em", "Fm", "F#m", "Gm", "G#m", "Am", "A#m", "Bm"
+]
+
+export const buildCanvaEmbedLink = link => {
+  const normalized = link.trim()
+  if (!normalized) return ""
+  if (normalized.includes("/view?embed")) return normalized
+
+  const withoutQuery = normalized.split("?")[0]
+
+  if (withoutQuery.endsWith("/view")) {
+    return `${withoutQuery}?embed`
+  }
+
+  if (withoutQuery.includes("/edit")) {
+    return `${withoutQuery.replace("/edit", "/view")}?embed`
+  }
+
+  return normalized
+}

--- a/pages/cargar.js
+++ b/pages/cargar.js
@@ -1,0 +1,72 @@
+import { useMemo, useState } from "react"
+import { Col, Form, Row, Typography, message } from "antd"
+import Layout from "@/components/layout/layout"
+import CanvaPreview from "@/components/cargar/canva-preview"
+import SongForm from "@/components/cargar/song-form"
+import { buildCanvaEmbedLink } from "@/lib/canva"
+
+const CargarPage = () => {
+  const [form] = Form.useForm()
+  const [canvaLink, setCanvaLink] = useState("")
+  const [preview, setPreview] = useState({
+    title: "Nueva canción",
+    tone: "C",
+    lyrics: ""
+  })
+
+  const embedLink = useMemo(() => buildCanvaEmbedLink(canvaLink), [canvaLink])
+
+  const handleFinish = values => {
+    message.success(`La canción "${values.title}" quedó lista para editar en Canva.`)
+  }
+
+  const resetForm = () => {
+    form.resetFields()
+    setCanvaLink("")
+    setPreview({
+      title: "Nueva canción",
+      tone: "C",
+      lyrics: ""
+    })
+  }
+
+  const handleValuesChange = (_, allValues) => {
+    setPreview({
+      title: allValues.title || "Nueva canción",
+      tone: allValues.tone || "C",
+      lyrics: allValues.lyrics || ""
+    })
+  }
+
+  return (
+    <Layout>
+      <div className="cargar-page">
+        <div className="section-header">
+          <Typography.Title level={2}>Cargar letras con tonos</Typography.Title>
+          <Typography.Paragraph className="hint-text">
+            Completa la información de la canción, agrega el tono y pega el enlace de tu diseño en Canva
+            para generar una vista previa integrada.
+          </Typography.Paragraph>
+        </div>
+        <Row gutter={[24, 24]}>
+          <Col xs={24} lg={12}>
+            <SongForm
+              form={form}
+              onFinish={handleFinish}
+              onValuesChange={handleValuesChange}
+              onReset={resetForm}
+              onCanvaChange={setCanvaLink} />
+          </Col>
+          <Col xs={24} lg={12}>
+            <CanvaPreview
+              preview={preview}
+              embedLink={embedLink}
+              canvaLink={canvaLink} />
+          </Col>
+        </Row>
+      </div>
+    </Layout>
+  )
+}
+
+export default CargarPage

--- a/pages/cargar.js
+++ b/pages/cargar.js
@@ -1,32 +1,41 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Col, Form, Row, Typography, message } from "antd"
 import Layout from "@/components/layout/layout"
 import CanvaPreview from "@/components/cargar/canva-preview"
 import SongForm from "@/components/cargar/song-form"
+import SectionsEditor from "@/components/cargar/sections-editor"
 import { buildCanvaEmbedLink } from "@/lib/canva"
+
+const baseSections = [
+  { id: 1, label: "Verso o intro", tone: "C", text: "" },
+  { id: 2, label: "Coro o estribillo", tone: "C", text: "" },
+  { id: 3, label: "Puente o cierre", tone: "C", text: "" }
+]
 
 const CargarPage = () => {
   const [form] = Form.useForm()
   const [canvaLink, setCanvaLink] = useState("")
+  const [sections, setSections] = useState(baseSections.map(section => ({ ...section })))
   const [preview, setPreview] = useState({
     title: "Nueva canción",
     tone: "C",
-    lyrics: ""
+    sections: baseSections.map(section => ({ ...section }))
   })
 
   const embedLink = useMemo(() => buildCanvaEmbedLink(canvaLink), [canvaLink])
 
   const handleFinish = values => {
-    message.success(`La canción "${values.title}" quedó lista para editar en Canva.`)
+    message.success(`La canción "${values.title}" quedó lista con ${sections.length} bloques de letra.`)
   }
 
   const resetForm = () => {
     form.resetFields()
     setCanvaLink("")
+    setSections(baseSections.map(section => ({ ...section })))
     setPreview({
       title: "Nueva canción",
       tone: "C",
-      lyrics: ""
+      sections: baseSections.map(section => ({ ...section }))
     })
   }
 
@@ -34,9 +43,30 @@ const CargarPage = () => {
     setPreview({
       title: allValues.title || "Nueva canción",
       tone: allValues.tone || "C",
-      lyrics: allValues.lyrics || ""
+      sections
     })
   }
+
+  const handleSectionChange = (id, field, value) => {
+    const updated = sections.map(section => section.id === id ? { ...section, [field]: value } : section)
+    setSections(updated)
+  }
+
+  const handleMoveSection = (index, direction) => {
+    const targetIndex = index + direction
+    if (targetIndex < 0 || targetIndex >= sections.length) return
+    const reordered = [...sections]
+    const [removed] = reordered.splice(index, 1)
+    reordered.splice(targetIndex, 0, removed)
+    setSections(reordered)
+  }
+
+  useEffect(() => {
+    setPreview(prev => ({
+      ...prev,
+      sections
+    }))
+  }, [sections])
 
   return (
     <Layout>
@@ -44,7 +74,7 @@ const CargarPage = () => {
         <div className="section-header">
           <Typography.Title level={2}>Cargar letras con tonos</Typography.Title>
           <Typography.Paragraph className="hint-text">
-            Completa la información de la canción, agrega el tono y pega el enlace de tu diseño en Canva
+            Completa la información de la canción, agrega el tono en cada bloque y pega el enlace de tu diseño en Canva
             para generar una vista previa integrada.
           </Typography.Paragraph>
         </div>
@@ -56,6 +86,10 @@ const CargarPage = () => {
               onValuesChange={handleValuesChange}
               onReset={resetForm}
               onCanvaChange={setCanvaLink} />
+            <SectionsEditor
+              sections={sections}
+              onChangeSection={handleSectionChange}
+              onMove={handleMoveSection} />
           </Col>
           <Col xs={24} lg={12}>
             <CanvaPreview

--- a/pages/chord-list.js
+++ b/pages/chord-list.js
@@ -1,0 +1,82 @@
+import { Card, Checkbox, Col, Input, List, Row, Typography } from "antd"
+import { useMemo, useState } from "react"
+import Layout from "@/components/layout/layout"
+
+const canciones = [
+  { id: 1, titulo: "Cielos y Tierra", tono: "E" },
+  { id: 2, titulo: "La Cruz", tono: "B" },
+  { id: 3, titulo: "Abres Camino", tono: "D" },
+  { id: 4, titulo: "Incomparable", tono: "G" },
+  { id: 5, titulo: "Tu Fidelidad", tono: "F" },
+  { id: 6, titulo: "Jesús", tono: "C" }
+]
+
+const ChordListPage = () => {
+  const [seleccionadas, setSeleccionadas] = useState([])
+  const [filtro, setFiltro] = useState("")
+
+  const visibles = useMemo(() => canciones.filter(cancion =>
+    cancion.titulo.toLowerCase().includes(filtro.toLowerCase())
+  ), [filtro])
+
+  const toggleCancion = id => {
+    setSeleccionadas(prev => prev.includes(id) ? prev.filter(item => item !== id) : [...prev, id])
+  }
+
+  return (
+    <Layout>
+      <div className="chord-list-page">
+        <div className="section-header">
+          <Typography.Title level={2}>Chord List</Typography.Title>
+          <Typography.Paragraph className="hint-text">
+            Marca las alabanzas que usarás en la reunión y confirma el tono.
+          </Typography.Paragraph>
+        </div>
+        <Row gutter={[16, 16]}>
+          <Col xs={24} md={12}>
+            <Card className="chord-list-card" title="Selecciona alabanzas">
+              <Input.Search
+                placeholder="Buscar por título"
+                allowClear
+                value={filtro}
+                onChange={event => setFiltro(event.target.value)} />
+              <List
+                dataSource={visibles}
+                renderItem={item => (
+                  <List.Item className="chord-item">
+                    <Checkbox
+                      checked={seleccionadas.includes(item.id)}
+                      onChange={() => toggleCancion(item.id)}>
+                      <div className="chord-text">
+                        <Typography.Text strong>{item.titulo}</Typography.Text>
+                        <Typography.Paragraph type="secondary">Tono: {item.tono}</Typography.Paragraph>
+                      </div>
+                    </Checkbox>
+                  </List.Item>
+                )} />
+            </Card>
+          </Col>
+          <Col xs={24} md={12}>
+            <Card className="chord-summary-card" title="Alabanzas seleccionadas">
+              {seleccionadas.length ? (
+                <List
+                  dataSource={canciones.filter(c => seleccionadas.includes(c.id))}
+                  renderItem={item => (
+                    <List.Item>
+                      <Typography.Text>{item.titulo} — {item.tono}</Typography.Text>
+                    </List.Item>
+                  )} />
+              ) : (
+                <Typography.Paragraph className="hint-text">
+                  Aún no has seleccionado alabanzas.
+                </Typography.Paragraph>
+              )}
+            </Card>
+          </Col>
+        </Row>
+      </div>
+    </Layout>
+  )
+}
+
+export default ChordListPage

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,8 +1,7 @@
 import LoginComponent from "@/components/auth/login-component"
 
-
 function Login() {
-  return(
+  return (
     <div>
       <LoginComponent />
     </div>

--- a/pages/registro.js
+++ b/pages/registro.js
@@ -1,0 +1,11 @@
+import RegisterComponent from "@/components/auth/register-component"
+
+function Registro() {
+  return (
+    <div>
+      <RegisterComponent />
+    </div>
+  )
+}
+
+export default Registro

--- a/pages/servicios.js
+++ b/pages/servicios.js
@@ -1,0 +1,68 @@
+import { Card, Col, List, Row, Tag, Typography } from "antd"
+import Layout from "@/components/layout/layout"
+
+const servicios = [
+  {
+    id: 1,
+    nombre: "Servicio Dominical",
+    fecha: "Próximo domingo 10:00 AM",
+    lugar: "Auditorio principal",
+    alabanzas: [
+      { titulo: "Eres Fiel", tono: "G" },
+      { titulo: "Glorioso Día", tono: "D" },
+      { titulo: "Danzando", tono: "A" }
+    ]
+  },
+  {
+    id: 2,
+    nombre: "Noche de Alabanza",
+    fecha: "Próximo viernes 7:30 PM",
+    lugar: "Sala juvenil",
+    alabanzas: [
+      { titulo: "Espíritu Ven", tono: "E" },
+      { titulo: "En Tu Presencia", tono: "C" },
+      { titulo: "Jardines en Llamas", tono: "B" }
+    ]
+  }
+]
+
+const ServiciosPage = () => (
+  <Layout>
+    <div className="servicios-page">
+      <div className="section-header">
+        <Typography.Title level={2}>Servicios próximos</Typography.Title>
+        <Typography.Paragraph className="hint-text">
+          Consulta las alabanzas preparadas para cada servicio y confirma los tonos antes del ensayo.
+        </Typography.Paragraph>
+      </div>
+      <Row gutter={[16, 16]}>
+        {servicios.map(servicio => (
+          <Col
+            xs={24}
+            md={12}
+            key={servicio.id}>
+            <Card className="servicio-card" title={servicio.nombre}>
+              <div className="servicio-meta">
+                <Tag color="green">{servicio.fecha}</Tag>
+                <Typography.Text type="secondary">{servicio.lugar}</Typography.Text>
+              </div>
+              <List
+                dataSource={servicio.alabanzas}
+                renderItem={item => (
+                  <List.Item className="servicio-item">
+                    <div>
+                      <Typography.Text strong>{item.titulo}</Typography.Text>
+                      <Typography.Paragraph type="secondary" className="servicio-tono">{`Tono sugerido: ${item.tono}`}</Typography.Paragraph>
+                    </div>
+                    <Tag color="processing">{item.tono}</Tag>
+                  </List.Item>
+                )} />
+            </Card>
+          </Col>
+        ))}
+      </Row>
+    </div>
+  </Layout>
+)
+
+export default ServiciosPage

--- a/styles/_components.scss
+++ b/styles/_components.scss
@@ -1,3 +1,4 @@
 @import "components/auth";
 @import "components/layout";
 @import "components/dashboard";
+@import "components/cargar";

--- a/styles/_components.scss
+++ b/styles/_components.scss
@@ -2,3 +2,5 @@
 @import "components/layout";
 @import "components/dashboard";
 @import "components/cargar";
+@import "components/servicios";
+@import "components/chord-list";

--- a/styles/components/auth.scss
+++ b/styles/components/auth.scss
@@ -43,6 +43,28 @@
       width: 100%;
     }
   }
+
+  .auth-extra {
+    text-align: center;
+    color: white;
+    display: grid;
+    gap: 8px;
+
+    .ant-typography {
+      color: white;
+    }
+  }
+
+  .auth-links {
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+
+    a {
+      color: #61dafb;
+    }
+  }
 }
-
-

--- a/styles/components/cargar.scss
+++ b/styles/components/cargar.scss
@@ -1,0 +1,75 @@
+.cargar-page {
+  padding: 32px 24px;
+  background: #f7f9fc;
+  min-height: 100vh;
+
+  .section-header {
+    margin-bottom: 24px;
+
+    .hint-text {
+      color: #6b7280;
+      max-width: 720px;
+    }
+  }
+
+  .upload-card,
+  .preview-card,
+  .canva-card {
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  }
+
+  .upload-card {
+    .ant-form-item-label > label {
+      font-weight: 600;
+      color: #1f2937;
+    }
+  }
+
+  .preview-card {
+    margin-bottom: 20px;
+
+    .preview-title {
+      margin-bottom: 4px;
+    }
+
+    .preview-tone {
+      color: #4b5563;
+      display: block;
+      margin-bottom: 12px;
+    }
+
+    .lyrics-preview {
+      min-height: 180px;
+      padding: 16px;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      white-space: pre-line;
+    }
+  }
+
+  .canva-card {
+    .canva-embed {
+      width: 100%;
+      min-height: 360px;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+    }
+
+    .empty-embed {
+      min-height: 180px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fff;
+      border: 1px dashed #cbd5e1;
+      border-radius: 10px;
+    }
+
+    .canva-actions {
+      margin-top: 10px;
+      text-align: right;
+    }
+  }
+}

--- a/styles/components/cargar.scss
+++ b/styles/components/cargar.scss
@@ -14,7 +14,8 @@
 
   .upload-card,
   .preview-card,
-  .canva-card {
+  .canva-card,
+  .sections-card {
     border-radius: 12px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
   }
@@ -40,12 +41,39 @@
     }
 
     .lyrics-preview {
-      min-height: 180px;
+      min-height: 220px;
       padding: 16px;
       background: #fff;
       border: 1px solid #e5e7eb;
       border-radius: 10px;
       white-space: pre-line;
+      display: grid;
+      gap: 12px;
+
+      .section-preview {
+        border: 1px dashed #d1d5db;
+        border-radius: 10px;
+        padding: 12px;
+        background: #f9fafb;
+
+        .section-header {
+          display: flex;
+          gap: 8px;
+          align-items: center;
+          margin-bottom: 6px;
+        }
+
+        .section-label {
+          font-weight: 600;
+          color: #111827;
+        }
+
+        .section-text {
+          margin: 0;
+          color: #374151;
+          white-space: pre-line;
+        }
+      }
     }
   }
 
@@ -70,6 +98,29 @@
     .canva-actions {
       margin-top: 10px;
       text-align: right;
+    }
+  }
+
+  .sections-card {
+    margin-top: 16px;
+
+    .section-item {
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+
+      .tone-select {
+        width: 100%;
+      }
+
+      .move-controls {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+      }
+
+      textarea {
+        resize: vertical;
+      }
     }
   }
 }

--- a/styles/components/chord-list.scss
+++ b/styles/components/chord-list.scss
@@ -1,0 +1,28 @@
+.chord-list-page {
+  padding: 32px 24px;
+  background: #f7f9fc;
+  min-height: 100vh;
+
+  .section-header {
+    margin-bottom: 20px;
+
+    .hint-text {
+      color: #6b7280;
+    }
+  }
+
+  .chord-list-card,
+  .chord-summary-card {
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  }
+
+  .chord-item {
+    padding-left: 4px;
+
+    .chord-text {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+}

--- a/styles/components/servicios.scss
+++ b/styles/components/servicios.scss
@@ -1,0 +1,38 @@
+.servicios-page {
+  padding: 32px 24px;
+  background: #f7f9fc;
+  min-height: 100vh;
+
+  .section-header {
+    margin-bottom: 20px;
+
+    .hint-text {
+      color: #6b7280;
+    }
+  }
+
+  .servicio-card {
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+
+    .servicio-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+
+    .servicio-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-radius: 8px;
+      padding: 12px;
+      background: #f8fafc;
+    }
+
+    .servicio-tono {
+      margin: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add local-storage helpers with a seeded user to simplify access
- enhance login to accept stored users and link to new registration page
- create registration form/component and shared auth styling updates

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943091c467c8328904e69f90b72896c)